### PR TITLE
Alterações no Cabeçalho e Títulos dos PDs

### DIFF
--- a/css/ceap.css
+++ b/css/ceap.css
@@ -264,6 +264,11 @@
             content: "Página " counter(page) " de " counter(pages);
         }
     }
+    @page relatorioPage:first {
+        @top-right {
+            content: normal;
+        }
+    }
     @page relatorioPage:blank,
     resumoPage:blank {
         @top-right {
@@ -444,7 +449,6 @@
     .accordion dt a {
         text-align: center;
         font-weight: 500;
-        padding: .5em;
         font-size: 16px;
         text-decoration: none;
     }


### PR DESCRIPTION
Alteração no cabeçalho do Relatório para que ele não aparecesse na
primeira página de cada seção;
Alteração nos títulos dos PDs para que não sobrescrevesse quando
houvesse a segunda linha;